### PR TITLE
Dashboard dlq

### DIFF
--- a/lambdas/httpGW/getDLQ.ts
+++ b/lambdas/httpGW/getDLQ.ts
@@ -1,0 +1,58 @@
+import { SQSClient, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import { APIGatewayProxyHandler } from "aws-lambda";
+
+const sqsClient = new SQSClient();
+
+export const handler: APIGatewayProxyHandler = async (event, context) => {
+  let allMessages: string[] = [];
+
+  try {
+    let messagesExist = true;
+    while (messagesExist) {
+      const receiveCommand = new ReceiveMessageCommand({
+        QueueUrl: process.env.DLQ_URL!,
+        MaxNumberOfMessages: 10,
+        WaitTimeSeconds: 0,
+        AttributeNames: ["All"],
+        MessageAttributeNames: ["All"],
+      });
+
+      const receiveResponse = await sqsClient.send(receiveCommand);
+
+      if (receiveResponse.Messages && receiveResponse.Messages.length > 0) {
+        const fetchedMessages: string[] = receiveResponse.Messages.map(
+          (message) => message.Body || ""
+        );
+
+        allMessages = [...allMessages, ...fetchedMessages];
+      } else {
+        messagesExist = false;
+      }
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(allMessages),
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error("Error fetching messages:", error.message);
+      return {
+        statusCode: 500,
+        body: JSON.stringify({
+          message: "Failed to fetch messages from the dead-letter queue.",
+          error: error.message,
+        }),
+      };
+    } else {
+      console.error("Unknown error:", error);
+      return {
+        statusCode: 500,
+        body: JSON.stringify({
+          message: "Failed to fetch messages from the dead-letter queue.",
+          error: "Unknown error",
+        }),
+      };
+    }
+  }
+};

--- a/lib/NaasStage.ts
+++ b/lib/NaasStage.ts
@@ -55,7 +55,6 @@ export class NaasStage extends Stage {
     new HttpGWStack(this, `HttpGWStack-${this.stageName}`, {
       env: props?.env,
       stageName: this.stageName,
-      dynamoLoggingStack,
       commonStack,
     });
   }

--- a/lib/stacks/CommonStack.ts
+++ b/lib/stacks/CommonStack.ts
@@ -26,6 +26,7 @@ export class CommonStack extends Stack {
   public readonly processRequest: aws_lambda_nodejs.NodejsFunction;
   public readonly SAVE_NOTIFICATION_FN: string;
   public readonly loggerQueue: aws_sqs.Queue;
+  public readonly dlq: aws_sqs.Queue;
 
   constructor(scope: Construct, id: string, props: CommonStackProps) {
     super(scope, id, props);
@@ -73,6 +74,7 @@ export class CommonStack extends Stack {
       queueName: `DeadLetterQueue-${stageName}`,
       retentionPeriod: Duration.days(14),
     });
+    this.dlq = dlq;
 
     // create LoggerQueue
     const loggerQueue = new aws_sqs.Queue(

--- a/lib/stacks/CommonStack.ts
+++ b/lib/stacks/CommonStack.ts
@@ -73,6 +73,7 @@ export class CommonStack extends Stack {
     const dlq = new aws_sqs.Queue(this, `deadLetterQueue-${stageName}`, {
       queueName: `DeadLetterQueue-${stageName}`,
       retentionPeriod: Duration.days(14),
+      visibilityTimeout: Duration.seconds(1),
     });
     this.dlq = dlq;
 

--- a/lib/stacks/HttpGWStack.ts
+++ b/lib/stacks/HttpGWStack.ts
@@ -14,14 +14,12 @@ import {
   aws_apigatewayv2_authorizers,
 } from "aws-cdk-lib";
 
-import { DynamoLoggingStack } from "./DynamoLoggingStack";
 import * as path from "path";
 import { CommonStack } from "./CommonStack";
 import * as dotenv from "dotenv";
 dotenv.config();
 
 interface HttpGWStackProps extends StackProps {
-  dynamoLoggingStack: DynamoLoggingStack;
   stageName: string;
   commonStack: CommonStack;
 }
@@ -37,6 +35,21 @@ export class HttpGWStack extends Stack {
 
     const stageName = props.stageName || "defaultStage";
     const commonStack = props.commonStack;
+
+    // create getDLQ lambda
+    const getDLQ = new aws_lambda_nodejs.NodejsFunction(
+      this,
+      `getDLQ-${stageName}`,
+      {
+        runtime: aws_lambda.Runtime.NODEJS_20_X,
+        handler: "handler",
+        entry: path.join(__dirname, "../../lambdas/httpGW/getDLQ.ts"),
+        environment: {
+          DLQ_URL: commonStack.dlq.queueUrl,
+        },
+      }
+    );
+    commonStack.dlq.grantConsumeMessages(getDLQ);
 
     // create userFunctions lambda
     const userFunctions = new aws_lambda_nodejs.NodejsFunction(
@@ -190,6 +203,20 @@ export class HttpGWStack extends Stack {
       integration: new aws_apigatewayv2_integrations.HttpLambdaIntegration(
         "UserFunctions",
         userFunctions,
+        {
+          payloadFormatVersion:
+            aws_apigatewayv2.PayloadFormatVersion.VERSION_2_0,
+        }
+      ),
+      authorizer: lambdaAuthorizer,
+    });
+
+    httpApi.addRoutes({
+      path: "/dlq",
+      methods: [aws_apigatewayv2.HttpMethod.GET],
+      integration: new aws_apigatewayv2_integrations.HttpLambdaIntegration(
+        "GetDLQ",
+        getDLQ,
         {
           payloadFormatVersion:
             aws_apigatewayv2.PayloadFormatVersion.VERSION_2_0,


### PR DESCRIPTION
Added a GET route on the HTTP API gateway for the `/dlq` endpoint to retrieve all messages in the DLQ.

Easiest way to test is to add messages to the DLQ on the console, then send a GET request to the `/dlq` endpoint.