### PR TITLE
sendEmail and broadcast send error logs to log table

### DIFF
--- a/lambdas/websocketGW/websocketBroadcast.ts
+++ b/lambdas/websocketGW/websocketBroadcast.ts
@@ -122,6 +122,16 @@ export const handler: Handler = async (event: EventType) => {
       };
     }
   } catch (error) {
+    const log: InAppLog = {
+      status: "Notification unable to be broadcast.",
+      notification_id: notification.notification_id,
+      user_id,
+      channel: "in-app",
+      body: {
+        message: notification.message,
+      },
+    };
+    await sendLog(log);
     console.error("Error broadcasting message:", error);
     return {
       statusCode: 500,


### PR DESCRIPTION
added an error log in the sendEmail and websocketBroadcast lambdas to not only log error messages to the console, but pass the error log to the queue to be logged in the notification log table with all the notification information. This allows the dashboard to display errors that have occured whilst attempting to broadcast/email notifications.

- If the response from Amazon SES is anything but a 200, it will log an error
- If there is an error within the try block of broadcasting the notification, it will log an error. 