### PR TITLE
fix: correcting in-app properties to be in_app

### DIFF
--- a/lambdas/dynamoNotifLogs/dynamoLogger.ts
+++ b/lambdas/dynamoNotifLogs/dynamoLogger.ts
@@ -24,7 +24,7 @@ async function getUserPreference(user_id: string, channel: string) {
   return response.Item![channel];
 }
 
-// pass notification to lambda for in-app notification
+// pass notification to lambda for in_app notification
 async function inAppNotification(log: NotificationLogType) {
   try {
     const command = new InvokeCommand({
@@ -77,7 +77,7 @@ function createLog(
     user_id,
     status, //notification created, notification sent, notification recieved
     message,
-    channel, // in-app, email, slack
+    channel, // in_app, email, slack
     notification_id,
   };
 

--- a/lambdas/types/index.ts
+++ b/lambdas/types/index.ts
@@ -20,7 +20,7 @@ export interface NotificationLogType {
   user_id: string;
   created_at: string;
   status?: string; //notification created, notification sent, notification recieved
-  channel: string; // in-app, email, slack
+  channel: string; // in_app, email, slack
   message: string;
   receiver_email?: string;
   subject?: string;
@@ -31,7 +31,7 @@ export interface InAppLog {
   status?: string;
   notification_id: string;
   user_id: string;
-  channel: "in-app";
+  channel: "in_app";
   body: {
     message: string;
   };

--- a/lambdas/websocketGW/sendInitialData.ts
+++ b/lambdas/websocketGW/sendInitialData.ts
@@ -59,7 +59,7 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    // query user preferences table to see if user wants to receive in-app notifiations
+    // query user preferences table to see if user wants to receive in_app notifiations
     const getCommand = new GetCommand({
       TableName: process.env.USER_PREFERENCES_TABLE,
       Key: { user_id },

--- a/lambdas/websocketGW/updateNotification.ts
+++ b/lambdas/websocketGW/updateNotification.ts
@@ -168,7 +168,7 @@ export const handler: Handler = async (event) => {
       status,
       notification_id,
       user_id,
-      channel: "in-app",
+      channel: "in_app",
       body: {
         message,
       },

--- a/lambdas/websocketGW/websocketBroadcast.ts
+++ b/lambdas/websocketGW/websocketBroadcast.ts
@@ -93,7 +93,7 @@ export const handler: Handler = async (event: EventType) => {
       status: "Notification queued for sending.",
       notification_id: notification.notification_id,
       user_id,
-      channel: "in-app",
+      channel: "in_app",
       body: {
         message: notification.message,
       },


### PR DESCRIPTION
made semantic changes. all references to in-app should now be corrected to in_app. 
Changes were also made in demo_app and frontend-sdk