### PR TITLE
feat: added dashboardAuthorizer

### DIFF
--- a/lambdas/httpGW/dashboardAuthorizer.ts
+++ b/lambdas/httpGW/dashboardAuthorizer.ts
@@ -1,0 +1,9 @@
+import { APIGatewayProxyEventV2 } from "aws-lambda";
+
+export const handler = async (event: APIGatewayProxyEventV2) => {
+  return {
+    isAuthorized:
+      event.headers.authorization === process.env.SECRET_KEY ||
+      event.headers.authorization === process.env.API_KEY,
+  };
+};

--- a/lambdas/httpGW/httpAuthorizer.ts
+++ b/lambdas/httpGW/httpAuthorizer.ts
@@ -1,4 +1,6 @@
-export const handler = async (event) => {
+import { APIGatewayProxyEventV2 } from "aws-lambda";
+
+export const handler = async (event: APIGatewayProxyEventV2) => {
   return {
     isAuthorized: event.headers.authorization === process.env.SECRET_KEY,
   };


### PR DESCRIPTION
Created `dashboardAuthorizer` lambda, which allows access if the `SECRET_KEY` OR `API_KEY` is provided.  Attached it to the following routes:

GET `/user/:user_id`
GET `/users`
GET `/notifications`
GET `/dlq`

