### PR TITLE
Output lambda names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 cdk.out
 .env
+cdk-output.json

--- a/lambdas/websocketGW/websocketBroadcast.ts
+++ b/lambdas/websocketGW/websocketBroadcast.ts
@@ -126,7 +126,7 @@ export const handler: Handler = async (event: EventType) => {
       status: "Notification unable to be broadcast.",
       notification_id: notification.notification_id,
       user_id,
-      channel: "in-app",
+      channel: "in_app",
       body: {
         message: notification.message,
       },

--- a/lib/stacks/CommonStack.ts
+++ b/lib/stacks/CommonStack.ts
@@ -83,7 +83,7 @@ export class CommonStack extends Stack {
       `notificationQueue-${stageName}`,
       {
         visibilityTimeout: Duration.seconds(30), // Optional: Customize visibility timeout
-        receiveMessageWaitTime: Duration.seconds(2),
+        receiveMessageWaitTime: Duration.seconds(6),
         deadLetterQueue: {
           queue: dlq,
           maxReceiveCount: 3,

--- a/lib/stacks/DynamoLoggingStack.ts
+++ b/lib/stacks/DynamoLoggingStack.ts
@@ -71,6 +71,7 @@ export class DynamoLoggingStack extends Stack {
         maxBatchingWindow: Duration.seconds(2),
         batchSize: 100,
         maxConcurrency: 10,
+        reportBatchItemFailures: true,
       })
     );
 

--- a/lib/stacks/HttpGWStack.ts
+++ b/lib/stacks/HttpGWStack.ts
@@ -121,7 +121,7 @@ export class HttpGWStack extends Stack {
     // create dashboard authorizer lambda
     const dashboardAuthorizer = new aws_lambda_nodejs.NodejsFunction(
       this,
-      `dashboardAuthorizer-${stageName}`,
+      `dashboardAuthorizerFn-${stageName}`,
       {
         runtime: aws_lambda.Runtime.NODEJS_20_X,
         handler: "handler",
@@ -301,6 +301,18 @@ export class HttpGWStack extends Stack {
       value: `https://${httpApi.apiId}.execute-api.${this.region}.amazonaws.com/${stageName}`,
       description: "invoke url for the http api dev stage",
       exportName: `HttpApiInvokeUrl-${stageName}`,
+    });
+
+    new CfnOutput(this, `HTTPAuthorizer-${stageName}`, {
+      value: httpAuthorizer.functionName,
+      description: "http gateway authorizer function name",
+      exportName: `HTTPAuthorizer-${stageName}`,
+    });
+
+    new CfnOutput(this, `dashboardAuthorizer-${stageName}`, {
+      value: dashboardAuthorizer.functionName,
+      description: "dashboard authorizer function name",
+      exportName: `dashboardAuthorizer-${stageName}`,
     });
   }
 }

--- a/lib/stacks/WebSocketGWStack.ts
+++ b/lib/stacks/WebSocketGWStack.ts
@@ -568,5 +568,11 @@ export class WebSocketGWStack extends Stack {
       exportName: `wssEndpoint-${stageName}`,
       value: `wss://${wsapi.ref}.execute-api.${this.region}.amazonaws.com/${stageName}`,
     });
+
+    new CfnOutput(this, `WebSocketAuthorizer-${stageName}`, {
+      value: websocketAuthorizer.functionName,
+      description: "websocket authorizer function name",
+      exportName: `WebSocketAuthorizer-${stageName}`,
+    });
   }
 }


### PR DESCRIPTION
Increasing message wait time for the queue from 2 seconds to 6 seconds.

Enabling the `dynamoLogger` lambda to add partial batch messages that failed back to the queue rather than having to return the entire message payload.

Adding cfn outputs for the authorizer resource names so they can be used by the CLI later.