### PR TITLE
feat: increased timeout on userFunctions and fetchNotifLogsFunctions

### DIFF
--- a/lib/stacks/HttpGWStack.ts
+++ b/lib/stacks/HttpGWStack.ts
@@ -67,6 +67,7 @@ export class HttpGWStack extends Stack {
           USERPREFS:
             commonStack.userPreferencesDdb.UserPreferencesDdb.tableName,
         },
+        timeout: Duration.seconds(120),
       }
     );
 
@@ -85,6 +86,7 @@ export class HttpGWStack extends Stack {
           NOTIFICATION_LOG_TABLE:
             commonStack.notificationLogsDB.NotificationLogTable.tableName,
         },
+        timeout: Duration.seconds(120),
       }
     );
 


### PR DESCRIPTION
Fetching many logs was hitting the default 3 second limit for lambdas.  Increased timeout to 120 seconds for lambdas that could possibly retrieve large data sets.