### PR TITLE
fix: added retention policies to all lambdas

### DIFF
--- a/lib/stacks/CommonStack.ts
+++ b/lib/stacks/CommonStack.ts
@@ -1,6 +1,7 @@
 import {
   aws_lambda,
   aws_lambda_nodejs,
+  aws_logs,
   aws_sqs,
   Duration,
   Stack,
@@ -108,6 +109,7 @@ export class CommonStack extends Stack {
           QUEUE_URL: loggerQueue.queueUrl,
         },
         timeout: Duration.seconds(10),
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
     this.processRequest = processRequest;

--- a/lib/stacks/DynamoLoggingStack.ts
+++ b/lib/stacks/DynamoLoggingStack.ts
@@ -5,6 +5,7 @@ import {
   aws_lambda,
   aws_lambda_event_sources,
   Duration,
+  aws_logs,
 } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as path from "path";
@@ -47,6 +48,7 @@ export class DynamoLoggingStack extends Stack {
             commonStack.userAttributesDB.UserAttributesTable.tableName,
         },
         timeout: Duration.seconds(10),
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
 
@@ -79,6 +81,7 @@ export class DynamoLoggingStack extends Stack {
           SLACK_NOTIFICATION: sendSlack.functionName,
         },
         timeout: Duration.seconds(20),
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
     this.dynamoLogger = dynamoLogger;

--- a/lib/stacks/HttpGWStack.ts
+++ b/lib/stacks/HttpGWStack.ts
@@ -47,6 +47,7 @@ export class HttpGWStack extends Stack {
         environment: {
           DLQ_URL: commonStack.dlq.queueUrl,
         },
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
     commonStack.dlq.grantConsumeMessages(getDLQ);
@@ -68,6 +69,7 @@ export class HttpGWStack extends Stack {
             commonStack.userPreferencesDdb.UserPreferencesDdb.tableName,
         },
         timeout: Duration.seconds(10),
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
 
@@ -87,6 +89,7 @@ export class HttpGWStack extends Stack {
             commonStack.notificationLogsDB.NotificationLogTable.tableName,
         },
         timeout: Duration.seconds(10),
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
 
@@ -103,6 +106,7 @@ export class HttpGWStack extends Stack {
         },
         timeout: Duration.seconds(29),
         memorySize: 256,
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
 
@@ -137,6 +141,7 @@ export class HttpGWStack extends Stack {
         },
         timeout: Duration.seconds(29),
         memorySize: 256,
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
 

--- a/lib/stacks/SesStack.ts
+++ b/lib/stacks/SesStack.ts
@@ -7,6 +7,7 @@ import {
   aws_lambda_nodejs,
   aws_lambda,
   Duration,
+  aws_logs,
 } from "aws-cdk-lib";
 import { CommonStack } from "./CommonStack";
 import * as path from "path";
@@ -43,6 +44,7 @@ export class SesStack extends Stack {
             commonStack.userAttributesDB.UserAttributesTable.tableName,
         },
         timeout: Duration.seconds(10),
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
     this.sendEmail = sendEmail;

--- a/lib/stacks/WebSocketGWStack.ts
+++ b/lib/stacks/WebSocketGWStack.ts
@@ -85,6 +85,7 @@ export class WebSocketGWStack extends Stack {
         },
         timeout: Duration.seconds(100),
         memorySize: 256,
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
 
@@ -119,6 +120,7 @@ export class WebSocketGWStack extends Stack {
             resources: ["*"],
           }),
         ],
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
     this.websocketBroadcast = websocketBroadcast;
@@ -143,6 +145,7 @@ export class WebSocketGWStack extends Stack {
         },
         timeout: Duration.seconds(100),
         memorySize: 256,
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
 
@@ -167,6 +170,7 @@ export class WebSocketGWStack extends Stack {
         timeout: Duration.seconds(100),
         memorySize: 256,
         functionName: commonStack.SAVE_NOTIFICATION_FN,
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
     this.saveActiveNotification = saveActiveNotification;
@@ -200,6 +204,7 @@ export class WebSocketGWStack extends Stack {
             resources: ["*"],
           }),
         ],
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
     this.updateNotification = updateNotification;
@@ -233,6 +238,7 @@ export class WebSocketGWStack extends Stack {
             resources: ["*"],
           }),
         ],
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
 
@@ -267,6 +273,7 @@ export class WebSocketGWStack extends Stack {
             resources: ["*"],
           }),
         ],
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
     this.sendInitialData = sendInitialData;
@@ -287,6 +294,7 @@ export class WebSocketGWStack extends Stack {
         },
         timeout: Duration.seconds(30),
         memorySize: 256,
+        logRetention: aws_logs.RetentionDays.ONE_MONTH,
       }
     );
 


### PR DESCRIPTION
Added a retention policy of 30 days to all lambdas. 
Logs older than 30 days will be periodically cleared from CloudWatch logs. 