### PR TITLE
fix: fixed cloudwatch log roles for websocket api

### DIFF
--- a/lib/stacks/WebSocketGWStack.ts
+++ b/lib/stacks/WebSocketGWStack.ts
@@ -1,5 +1,6 @@
 import { Construct } from "constructs";
 import {
+  aws_apigateway,
   aws_apigatewayv2,
   aws_iam,
   aws_lambda,
@@ -534,6 +535,11 @@ export class WebSocketGWStack extends Stack {
     // create a role for API Gateway
     const apiGatewayRole = new aws_iam.Role(this, "ApiGatewayLoggingRole", {
       assumedBy: new aws_iam.ServicePrincipal("apigateway.amazonaws.com"),
+      managedPolicies: [
+        aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+        ),
+      ],
     });
 
     // Grant API Gateway permissions to write to Cloudwatch logs
@@ -566,6 +572,10 @@ export class WebSocketGWStack extends Stack {
           responseLength: "$context.responseLength",
         }),
       },
+    });
+
+    new aws_apigateway.CfnAccount(this, "EnableCloudWatchLogs", {
+      cloudWatchRoleArn: apiGatewayRole.roleArn,
     });
 
     // add deployment dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "naas-cdk",
+  "name": "telegraph-cdk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "naas-cdk",
+      "name": "telegraph-cdk",
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-apigatewaymanagementapi": "^3.679.0",
@@ -22,9 +22,6 @@
         "constructs": "^10.0.0",
         "dotenv": "^16.4.5",
         "source-map-support": "^0.5.21"
-      },
-      "bin": {
-        "naas-cdk": "bin/naas-cdk.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",


### PR DESCRIPTION
IAM roles for WebSocket gateway cloudwatch logs needed additional permissions.